### PR TITLE
ci: add reviewer to fix-dependabot PR creation

### DIFF
--- a/.github/workflows/fix-dependabot.yml
+++ b/.github/workflows/fix-dependabot.yml
@@ -345,4 +345,5 @@ jobs:
             --title "fix: resolve Dependabot vulnerabilities ($(date +%Y-%m-%d))" \
             --base "$BASE_BRANCH" \
             --head "$BRANCH" \
-            --body-file "${RUNNER_TEMP}/pr-body.txt"
+            --body-file "${RUNNER_TEMP}/pr-body.txt" \
+            --reviewer i-s-23


### PR DESCRIPTION
## 変更内容

`fix-dependabot.yml` が作成する修正 PR に、レビュアーとして `i-s-23` を自動指定するよう変更。

## 差分

```diff
           gh pr create \
             --title "fix: resolve Dependabot vulnerabilities ($(date +%Y-%m-%d))" \
             --base "$BASE_BRANCH" \
             --head "$BRANCH" \
-            --body-file "${RUNNER_TEMP}/pr-body.txt"
+            --body-file "${RUNNER_TEMP}/pr-body.txt" \
+            --reviewer i-s-23
```